### PR TITLE
Make logs from withdrawing more clear

### DIFF
--- a/main.go
+++ b/main.go
@@ -171,6 +171,15 @@ func main() {
 		log.Fatalf("Error binding L2OutputOracle contract: %v", err)
 	}
 
+	isFinalized, err := withdraw.ProofFinalized(ctx, portal, withdrawal)
+	if err != nil {
+		log.Fatalf("Error querying withdrawal finalization status: %v", err)
+	}
+	if isFinalized {
+		fmt.Println("Withdrawal already finalized")
+		return
+	}
+
 	finalizationPeriod, err := l2oo.FINALIZATIONPERIODSECONDS(&bind.CallOpts{})
 	if err != nil {
 		log.Fatalf("Error querying withdrawal finalization period: %v", err)


### PR DESCRIPTION
We use this code to automate withdrawals of sequencer revenue - noticed some things in the logs that we could cleanup

* waitForConfirmation should have a timeout
* certain places return errors that seem more informational vs an issue
* check for finalization status before trying to prove/finalize