### PR TITLE
chore(CHAIN-2829): replace fmt.Printf with structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func main() {
 		log.Crit("Error querying withdrawal finalization status", "error", err)
 	}
 	if isFinalized {
-		fmt.Println("Withdrawal already finalized")
+		log.Info("Withdrawal already finalized")
 		return
 	}
 
@@ -313,9 +313,9 @@ func main() {
 		}
 
 		if faultProofs {
-			fmt.Println("The withdrawal has been successfully proven, finalization of the withdrawal can be done once the dispute game has finished and the finalization period has elapsed")
+			log.Info("Withdrawal successfully proven, finalize once dispute game finishes and finalization period elapses")
 		} else {
-			fmt.Println("The withdrawal has been successfully proven, finalization of the withdrawal can be done once the finalization period has elapsed")
+			log.Info("Withdrawal successfully proven, finalize once finalization period elapses")
 		}
 		return
 	}

--- a/withdraw/fpwithdraw.go
+++ b/withdraw/fpwithdraw.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -139,7 +140,7 @@ func (w *FPWithdrawer) ProveWithdrawal() error {
 		return err
 	}
 
-	fmt.Printf("Proved withdrawal for %s: %s\n", w.L2TxHash.String(), tx.Hash().String())
+	log.Info("Proved withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
 
 	// Wait 5 mins max for confirmation
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)
@@ -210,7 +211,7 @@ func (w *FPWithdrawer) FinalizeWithdrawal() error {
 		return err
 	}
 
-	fmt.Printf("Completed withdrawal for %s: %s\n", w.L2TxHash.String(), tx.Hash().String())
+	log.Info("Completed withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
 
 	// Wait 5 mins max for confirmation
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)

--- a/withdraw/withdraw.go
+++ b/withdraw/withdraw.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/ethclient/gethclient"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -151,7 +152,7 @@ func (w *Withdrawer) ProveWithdrawal() error {
 		return err
 	}
 
-	fmt.Printf("Proved withdrawal for %s: %s\n", w.L2TxHash.String(), tx.Hash().String())
+	log.Info("Proved withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
 
 	// Wait 5 mins max for confirmation
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)
@@ -258,7 +259,7 @@ func (w *Withdrawer) FinalizeWithdrawal() error {
 		return err
 	}
 
-	fmt.Printf("Completed withdrawal for %s: %s\n", w.L2TxHash.String(), tx.Hash().String())
+	log.Info("Completed withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
 
 	// Wait 5 mins max for confirmation
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)


### PR DESCRIPTION
Convert all fmt.Printf/fmt.Println calls in the withdraw package and main.go to use the structured logger (go-ethereum/log). This ensures consistent log output through the oplog-configured logger rather than mixing structured stderr logs with unstructured stdout prints.