### PR TITLE
docs: fix typo in flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Usage of withdrawer:
     -rpc string
         Ethereum L1 RPC url
     -network string
-        op-stack network to withdraw.go from (one of: base-mainnet, base-sepolia, op-mainnet, op-sepolia) (default "base-mainnet")
+        op-stack network to withdraw from (one of: base-mainnet, base-sepolia, op-mainnet, op-sepolia) (default "base-mainnet")
     -withdrawal string
         TX hash of the L2 withdrawal transaction
     -fault-proofs

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	var maxGasPrice string
 
 	flag.StringVar(&rpcFlag, "rpc", "", "Ethereum L1 RPC url")
-	flag.StringVar(&networkFlag, "network", "base-mainnet", fmt.Sprintf("op-stack network to withdraw.go from (one of: %s)", strings.Join(networkKeys, ", ")))
+	flag.StringVar(&networkFlag, "network", "base-mainnet", fmt.Sprintf("op-stack network to withdraw from (one of: %s)", strings.Join(networkKeys, ", ")))
 	flag.StringVar(&l2RpcFlag, "l2-rpc", "", "Custom network L2 RPC url")
 	flag.BoolVar(&faultProofs, "fault-proofs", false, "Use fault proofs")
 	flag.StringVar(&portalAddress, "portal-address", "", "Custom network OptimismPortal address")


### PR DESCRIPTION
This PR fixes a minor typo in the `network` flag documentation where it said `withdraw.go from` instead of `withdraw from`.