### PR TITLE
feat(BASE-104): add support for L3 withdrawals requiring instant finality

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 	var networkFlag string
 	var l2RpcFlag string
 	var faultProofs bool
+	var instantFinality bool
 	var portalAddress string
 	var l2OOAddress string
 	var dgfAddress string
@@ -110,6 +111,7 @@ func main() {
 	flag.StringVar(&networkFlag, "network", "base-mainnet", fmt.Sprintf("op-stack network to withdraw.go from (one of: %s)", strings.Join(networkKeys, ", ")))
 	flag.StringVar(&l2RpcFlag, "l2-rpc", "", "Custom network L2 RPC url")
 	flag.BoolVar(&faultProofs, "fault-proofs", false, "Use fault proofs")
+	flag.BoolVar(&instantFinality, "instant-finality", false, "Use single-transaction prove-and-finalize for L3 chains with TEE-backed immediate finality")
 	flag.StringVar(&portalAddress, "portal-address", "", "Custom network OptimismPortal address")
 	flag.StringVar(&l2OOAddress, "l2oo-address", "", "Custom network L2OutputOracle address")
 	flag.StringVar(&dgfAddress, "dgf-address", "", "Custom network DisputeGameFactory address")
@@ -136,6 +138,11 @@ func main() {
 	n, ok := networks[networkFlag]
 	if !ok {
 		log.Crit("Unknown network", "network", networkFlag)
+	}
+
+	// --instant-finality implies --fault-proofs
+	if instantFinality {
+		faultProofs = true
 	}
 
 	// check for non-compatible networks with given flags
@@ -313,6 +320,16 @@ func main() {
 		log.Crit("Withdrawal is not provable", "error", err)
 	}
 
+	if instantFinality {
+		log.Info("Instant finality mode: proving and finalizing withdrawal in a single transaction")
+		err = withdrawer.ProveAndFinalizeWithdrawal()
+		if err != nil {
+			log.Crit("Error proving and finalizing withdrawal", "error", err)
+		}
+		log.Info("Withdrawal successfully proven and finalized")
+		return
+	}
+
 	proofTime, err := withdrawer.GetProvenWithdrawalTime()
 	if err != nil {
 		log.Crit("Error querying withdrawal proof", "error", err)
@@ -448,6 +465,7 @@ func CreateWithdrawHelper(l1Rpc string, withdrawal common.Hash, n network, s sig
 			Factory:             dgf,
 			AnchorStateRegistry: anchorStateRegistry,
 			Opts:                l1opts,
+			PortalAddress:       common.HexToAddress(n.portalAddress),
 			GasMultiplier:       gasConfig.GasMultiplier,
 			UserGasLimit:        gasConfig.GasLimit,
 			DryRun:              dryRun,

--- a/main.go
+++ b/main.go
@@ -142,6 +142,9 @@ func main() {
 
 	// --instant-finality implies --fault-proofs
 	if instantFinality {
+		if !n.faultProofs {
+			log.Crit("Instant finality requires a fault proofs network", "network", networkFlag)
+		}
 		faultProofs = true
 	}
 

--- a/withdraw/fpwithdraw.go
+++ b/withdraw/fpwithdraw.go
@@ -29,9 +29,10 @@ type FPWithdrawer struct {
 	Factory             *bindings.DisputeGameFactory
 	AnchorStateRegistry *withdrawerbindings.AnchorStateRegistry
 	Opts                *bind.TransactOpts
-	GasMultiplier       float64 // Multiplier for estimated gas (default 1.0)
-	UserGasLimit        uint64  // Original user-specified gas limit (0 means auto-estimate)
-	DryRun              bool    // Simulate transactions without submitting
+	PortalAddress       common.Address // Portal address for instant finality binding
+	GasMultiplier       float64        // Multiplier for estimated gas (default 1.0)
+	UserGasLimit        uint64         // Original user-specified gas limit (0 means auto-estimate)
+	DryRun              bool           // Simulate transactions without submitting
 }
 
 func (w *FPWithdrawer) CheckIfProvable() error {
@@ -169,6 +170,71 @@ func (w *FPWithdrawer) ProveWithdrawal() error {
 	log.Info("Proved withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
 
 	// Wait 5 mins max for confirmation
+	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)
+	defer cancel()
+	return waitForConfirmation(ctxWithTimeout, w.L1Client, tx.Hash())
+}
+
+func (w *FPWithdrawer) ProveAndFinalizeWithdrawal() error {
+	portal, err := newInstantFinalityPortal(w.PortalAddress, w.L1Client)
+	if err != nil {
+		return fmt.Errorf("failed to bind instant finality portal: %w", err)
+	}
+
+	l2 := ethclient.NewClient(w.L2Client)
+	l2g := gethclient.New(w.L2Client)
+
+	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(w.Ctx, l2g, l2, l2, w.L2TxHash, &w.Factory.DisputeGameFactoryCaller, &w.Portal.OptimismPortal2Caller)
+	if err != nil {
+		return err
+	}
+
+	withdrawalTx := bindingspreview.TypesWithdrawalTransaction{
+		Nonce:    params.Nonce,
+		Sender:   params.Sender,
+		Target:   params.Target,
+		Value:    params.Value,
+		GasLimit: params.GasLimit,
+		Data:     params.Data,
+	}
+	outputRootProof := bindingspreview.TypesOutputRootProof{
+		Version:                  params.OutputRootProof.Version,
+		StateRoot:                params.OutputRootProof.StateRoot,
+		MessagePasserStorageRoot: params.OutputRootProof.MessagePasserStorageRoot,
+		LatestBlockhash:          params.OutputRootProof.LatestBlockhash,
+	}
+
+	simulatedTx, err := prepareGasOpts(w.Opts, w.UserGasLimit, w.GasMultiplier, w.DryRun, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return portal.ProveAndFinalizeWithdrawalTransaction(
+			opts,
+			withdrawalTx,
+			params.L2OutputIndex,
+			outputRootProof,
+			params.WithdrawalProof,
+		)
+	})
+	if err != nil {
+		return err
+	}
+
+	if w.DryRun {
+		printDryRun("ProveAndFinalizeWithdrawal", simulatedTx, w.Opts.From, w.Opts.GasLimit)
+		return nil
+	}
+
+	tx, err := portal.ProveAndFinalizeWithdrawalTransaction(
+		w.Opts,
+		withdrawalTx,
+		params.L2OutputIndex,
+		outputRootProof,
+		params.WithdrawalProof,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Proved and finalized withdrawal", "l2TxHash", w.L2TxHash, "l1TxHash", tx.Hash())
+
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)
 	defer cancel()
 	return waitForConfirmation(ctxWithTimeout, w.L1Client, tx.Hash())

--- a/withdraw/instant_finality.go
+++ b/withdraw/instant_finality.go
@@ -1,0 +1,39 @@
+package withdraw
+
+import (
+	"math/big"
+	"strings"
+
+	bindingspreview "github.com/ethereum-optimism/optimism/op-node/bindings/preview"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const proveAndFinalizeABI = `[{"inputs":[{"components":[{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"address","name":"sender","type":"address"},{"internalType":"address","name":"target","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"uint256","name":"gasLimit","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"internalType":"struct Types.WithdrawalTransaction","name":"_tx","type":"tuple"},{"internalType":"uint256","name":"_disputeGameIndex","type":"uint256"},{"components":[{"internalType":"bytes32","name":"version","type":"bytes32"},{"internalType":"bytes32","name":"stateRoot","type":"bytes32"},{"internalType":"bytes32","name":"messagePasserStorageRoot","type":"bytes32"},{"internalType":"bytes32","name":"latestBlockhash","type":"bytes32"}],"internalType":"struct Types.OutputRootProof","name":"_outputRootProof","type":"tuple"},{"internalType":"bytes[]","name":"_withdrawalProof","type":"bytes[]"}],"name":"proveAndFinalizeWithdrawalTransaction","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
+
+// instantFinalityPortal provides access to the proveAndFinalizeWithdrawalTransaction
+// method on OptimismPortal2 contracts configured for TEE-backed immediate finality.
+type instantFinalityPortal struct {
+	contract *bind.BoundContract
+}
+
+func newInstantFinalityPortal(address common.Address, backend bind.ContractBackend) (*instantFinalityPortal, error) {
+	parsed, err := abi.JSON(strings.NewReader(proveAndFinalizeABI))
+	if err != nil {
+		return nil, err
+	}
+	contract := bind.NewBoundContract(address, parsed, backend, backend, backend)
+	return &instantFinalityPortal{contract: contract}, nil
+}
+
+func (p *instantFinalityPortal) ProveAndFinalizeWithdrawalTransaction(
+	opts *bind.TransactOpts,
+	_tx bindingspreview.TypesWithdrawalTransaction,
+	_disputeGameIndex *big.Int,
+	_outputRootProof bindingspreview.TypesOutputRootProof,
+	_withdrawalProof [][]byte,
+) (*types.Transaction, error) {
+	return p.contract.Transact(opts, "proveAndFinalizeWithdrawalTransaction", _tx, _disputeGameIndex, _outputRootProof, _withdrawalProof)
+}

--- a/withdraw/utils.go
+++ b/withdraw/utils.go
@@ -21,6 +21,7 @@ type WithdrawHelper interface {
 	CheckIfProvable() error
 	GetProvenWithdrawalTime() (uint64, error)
 	ProveWithdrawal() error
+	ProveAndFinalizeWithdrawal() error
 	IsProofFinalized() (bool, error)
 	FinalizeWithdrawal() error
 }

--- a/withdraw/withdraw.go
+++ b/withdraw/withdraw.go
@@ -160,6 +160,10 @@ func (w *Withdrawer) ProveWithdrawal() error {
 	return waitForConfirmation(ctxWithTimeout, w.L1Client, tx.Hash())
 }
 
+func (w *Withdrawer) ProveAndFinalizeWithdrawal() error {
+	return errors.New("instant finality is only supported with fault proofs (--fault-proofs)")
+}
+
 func (w *Withdrawer) IsProofFinalized() (bool, error) {
 	hash, err := w.getWithdrawalHash()
 	if err != nil {


### PR DESCRIPTION
Introduces utilities targeting instantaneous TEE-trusted finality, aligned with l3 changes added for [base/base](https://github.com/base/base/pull/3355) and [base/contracts](https://github.com/base/contracts/pull/328)

Addresses BASE-104

## Note on limitations

This repository currently only provides withdrawal capabilities on a manual, per-user basis (to exit Base to Ethereum). This PR in turn adds the bare minimum to add support for instant finality L3s, also on a manual per-user basis. Future work should investigate a way to extend the functionality introduced in this PR to run as an automated service, detecting withdrawals signaled on the L2 and automatically relaying + settling them on the L3.  I suggest we reuse the code already built in this branch, adding serve subcommand to the base/withdrawer CLI that runs as a long-lived daemon to deliver a fully automated withdrawal experience for chains with TEE-backed instant finality.

## Summary

Adds `--instant-finality` CLI flag that enables single-transaction withdrawal proving and finalization for L3 appchains with TEE-backed immediate finality. This calls `proveAndFinalizeWithdrawalTransaction` on OptimismPortal2 instead of the separate prove → wait → finalize flow.

- New `--instant-finality` flag (implies `--fault-proofs`)
- Reuses existing proof parameter generation, gas handling, dry-run, and confirmation patterns
- No behavioral changes when the flag is not set

## Context

Companion to the contract changes in `base/contracts` (`l3-changes` branch) which introduce `proveAndFinalizeWithdrawalTransaction` on OptimismPortal2 for chains where `PROOF_MATURITY_DELAY_SECONDS == 0` and `disputeGameFinalityDelaySeconds == 0` (changes in `base/base`).