### PR TITLE
fix: set --fault-proofs default to true for built-in fault-proof networks

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 	flag.StringVar(&rpcFlag, "rpc", "", "Ethereum L1 RPC url")
 	flag.StringVar(&networkFlag, "network", "base-mainnet", fmt.Sprintf("op-stack network to withdraw.go from (one of: %s)", strings.Join(networkKeys, ", ")))
 	flag.StringVar(&l2RpcFlag, "l2-rpc", "", "Custom network L2 RPC url")
-	flag.BoolVar(&faultProofs, "fault-proofs", false, "Use fault proofs")
+	flag.BoolVar(&faultProofs, "fault-proofs", true, "Use fault proofs")
 	flag.StringVar(&portalAddress, "portal-address", "", "Custom network OptimismPortal address")
 	flag.StringVar(&l2OOAddress, "l2oo-address", "", "Custom network L2OutputOracle address")
 	flag.StringVar(&dgfAddress, "dgf-address", "", "Custom network DisputeGameFactory address")


### PR DESCRIPTION
All four built-in networks (base-mainnet, base-sepolia, op-mainnet, op-sepolia) have `faultProofs: true` and `l2oo-address` set to `0x0`. But the `--fault-proofs` CLI flag defaults to `false`, causing a crash when users run simple commands without the flag.

Change the default from `false` to `true` to match the network configurations.

Closes #87