### PR TITLE
docs(readme): add --dry-run flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Usage of withdrawer:
     -asr-address string
         Custom network AnchorStateRegistry address (only for networks that support fault proofs)
 
+    -dry-run
+        Simulate transactions and print details without submitting
+
     -gas-limit uint
         Gas limit for transactions (overrides automatic estimation)
     -gas-price string


### PR DESCRIPTION
Fixes #89.

The --dry-run flag was added in PR #74 but was not included in the README flag reference. Added it to the flags section alongside the gas configuration options.